### PR TITLE
Add app label for kafka pods.

### DIFF
--- a/kafka-cluster.yaml
+++ b/kafka-cluster.yaml
@@ -11,6 +11,7 @@ spec:
     metadata:
       labels:
         name: kafka
+        app: kafka
     spec:
       containers:
       - name: kafka


### PR DESCRIPTION
The app label was missing on the pod spec so the kafka-service would not pick it up.